### PR TITLE
feat(i18n): thread language through AI provider chain

### DIFF
--- a/sidecar/ai.test.ts
+++ b/sidecar/ai.test.ts
@@ -23,8 +23,8 @@ describe("AI Prompt 分析逻辑", () => {
   test("buildAnalysisPrompt 应该支持自定义 contentLimit", () => {
     const longContent = "A".repeat(2000);
     const news = [{ title: "Test", source: "Test", content: longContent }];
-    const prompt800 = buildAnalysisPrompt("TEST", news, 800);
-    const prompt1000 = buildAnalysisPrompt("TEST", news, 1000);
+    const prompt800 = buildAnalysisPrompt("TEST", news, 'zh', 800);
+    const prompt1000 = buildAnalysisPrompt("TEST", news, 'zh', 1000);
     // 800 截断应该比 1000 截断的结果短
     expect(prompt800.length).toBeLessThan(prompt1000.length);
   });
@@ -36,8 +36,8 @@ describe("AI Prompt 分析逻辑", () => {
     const newsShort = [{ title: "T", source: "S", content: shortContent }];
     const newsLong  = [{ title: "T", source: "S", content: longContent }];
 
-    const promptShort = buildAnalysisPrompt("TEST", newsShort, 500);
-    const promptLong  = buildAnalysisPrompt("TEST", newsLong,  500);
+    const promptShort = buildAnalysisPrompt("TEST", newsShort, 'zh', 500);
+    const promptLong  = buildAnalysisPrompt("TEST", newsLong,  'zh', 500);
 
     // 超出 500 字符的正文应被截断，导致 prompt 长度不随原始内容线性增长
     expect(promptLong.length).toBeLessThan(promptShort.length + longContent.length);

--- a/sidecar/ai.ts
+++ b/sidecar/ai.ts
@@ -1,4 +1,4 @@
-import type { AIAnalysisResult, StockNews, QuantBundle } from '../shared/types';
+import type { AIAnalysisResult, StockNews, QuantBundle, Language } from '../shared/types';
 
 /** Provider 家族标识——工厂派发结果可被单测断言。
  * deepseek 复用 OpenAI 兼容协议，其 Provider 实例的 kind 为 'openai'，故不在此列。
@@ -17,5 +17,5 @@ export interface AIProvider {
    * @param symbol 股票代码
    * @param news 相关新闻列表
    */
-  analyze(symbol: string, news: StockNews[], quant?: QuantBundle): Promise<AIAnalysisResult>;
+  analyze(symbol: string, news: StockNews[], quant?: QuantBundle, language?: Language): Promise<AIAnalysisResult>;
 }

--- a/sidecar/analysis.ts
+++ b/sidecar/analysis.ts
@@ -1,4 +1,4 @@
-import type { AIAnalysisResult, FullAnalysisResponse, MarketBundle, StockInfo, StockNews, QuantBundle } from '../shared/types';
+import type { AIAnalysisResult, FullAnalysisResponse, MarketBundle, StockInfo, StockNews, QuantBundle, Language } from '../shared/types';
 import type { ParsedSymbol } from './parsers/exchange';
 import type { AIProvider } from './ai';
 import { scrapeStockNews as realScrape } from './scraper';
@@ -24,7 +24,7 @@ export interface AnalysisDeps {
   scrape?: typeof realScrape;
   fetchInfo?: (parsed: ParsedSymbol) => Promise<StockInfo | null>;
   enhance?: typeof realEnhance;
-  createProvider?: (type: string, cfg: { apiKey?: string; baseUrl?: string; model?: string }) => AIProvider;
+  createProvider?: (type: string, cfg: { apiKey?: string; baseUrl?: string; model?: string; language?: Language }) => AIProvider;
 }
 
 function resolveDeps(deps: AnalysisDeps): Required<AnalysisDeps> {
@@ -73,14 +73,14 @@ export async function analyzeNewsWithLLM(
   symbol: string,
   news: StockNews[],
   providerType: string = 'openai',
-  config: { apiKey?: string; baseUrl?: string; model?: string } = {},
+  config: { apiKey?: string; baseUrl?: string; model?: string; language?: Language } = {},
   quant?: QuantBundle,
   deps: AnalysisDeps = {},
 ): Promise<AIAnalysisResult> {
   const createProvider = deps.createProvider ?? realCreateProvider;
   try {
     const provider = createProvider(providerType, config);
-    return await provider.analyze(symbol, news, quant);
+    return await provider.analyze(symbol, news, quant, config.language);
   } catch (error) {
     const msg = toErrorMessage(error);
     logger.error(`AI 分析异常 (${symbol}): ${msg}`);
@@ -100,7 +100,7 @@ export async function analyzeNewsWithLLM(
 export async function performFullAnalysis(
   symbol: string,
   providerType: string = 'openai',
-  config: { apiKey?: string; baseUrl?: string; model?: string; deepMode?: boolean } = {},
+  config: { apiKey?: string; baseUrl?: string; model?: string; deepMode?: boolean; language?: Language } = {},
   deps: AnalysisDeps = {},
 ): Promise<FullAnalysisResponse> {
   const bundle = await fetchMarketBundle(symbol, config.deepMode ?? true, deps);

--- a/sidecar/providers/anthropic.ts
+++ b/sidecar/providers/anthropic.ts
@@ -1,8 +1,8 @@
 import Anthropic from "@anthropic-ai/sdk";
-import type { AIAnalysisResult, StockNews, QuantBundle } from "../../shared/types";
+import type { AIAnalysisResult, StockNews, QuantBundle, Language } from "../../shared/types";
 import type { AIProvider, ProviderKind } from "../ai";
 import { PROVIDER_PROFILES } from "../config";
-import { buildAnalysisPrompt, buildEnhancedPrompt, SYSTEM_PROMPT } from "../prompts";
+import { buildAnalysisPrompt, buildEnhancedPrompt, getSystemPrompt } from "../prompts";
 import { toErrorMessage, withTimeout, logger, parseJsonFromAi } from "../utils";
 
 /**
@@ -18,17 +18,18 @@ export class AnthropicProvider implements AIProvider {
     this.model = model;
   }
 
-  async analyze(symbol: string, news: StockNews[], quant?: QuantBundle): Promise<AIAnalysisResult> {
+  async analyze(symbol: string, news: StockNews[], quant?: QuantBundle, language?: Language): Promise<AIAnalysisResult> {
+    const lang = language ?? 'zh';
     const prompt = quant
-      ? buildEnhancedPrompt(symbol, news, quant, 'zh', PROVIDER_PROFILES.anthropic.contentLimit)
-      : buildAnalysisPrompt(symbol, news, 'zh', PROVIDER_PROFILES.anthropic.contentLimit);
+      ? buildEnhancedPrompt(symbol, news, quant, lang, PROVIDER_PROFILES.anthropic.contentLimit)
+      : buildAnalysisPrompt(symbol, news, lang, PROVIDER_PROFILES.anthropic.contentLimit);
 
     try {
       const response = await withTimeout(
         this.client.messages.create({
           model: this.model,
           max_tokens: 1024,
-          system: SYSTEM_PROMPT,
+          system: getSystemPrompt(lang),
           messages: [{ role: "user", content: prompt }],
         }),
         PROVIDER_PROFILES.anthropic.timeout,

--- a/sidecar/providers/ollama.ts
+++ b/sidecar/providers/ollama.ts
@@ -1,8 +1,8 @@
 import { Ollama } from "ollama";
-import type { AIAnalysisResult, StockNews, QuantBundle } from "../../shared/types";
+import type { AIAnalysisResult, StockNews, QuantBundle, Language } from "../../shared/types";
 import type { AIProvider, ProviderKind } from "../ai";
 import { PROVIDER_PROFILES } from "../config";
-import { buildAnalysisPrompt, buildEnhancedPrompt, SYSTEM_PROMPT } from "../prompts";
+import { buildAnalysisPrompt, buildEnhancedPrompt, getSystemPrompt } from "../prompts";
 import { toErrorMessage, withTimeout, logger, parseJsonFromAi } from "../utils";
 
 /**
@@ -18,17 +18,18 @@ export class OllamaProvider implements AIProvider {
     this.model = model;
   }
 
-  async analyze(symbol: string, news: StockNews[], quant?: QuantBundle): Promise<AIAnalysisResult> {
+  async analyze(symbol: string, news: StockNews[], quant?: QuantBundle, language?: Language): Promise<AIAnalysisResult> {
+    const lang = language ?? 'zh';
     const prompt = quant
-      ? buildEnhancedPrompt(symbol, news, quant, 'zh', PROVIDER_PROFILES.ollama.contentLimit)
-      : buildAnalysisPrompt(symbol, news, 'zh', PROVIDER_PROFILES.ollama.contentLimit);
+      ? buildEnhancedPrompt(symbol, news, quant, lang, PROVIDER_PROFILES.ollama.contentLimit)
+      : buildAnalysisPrompt(symbol, news, lang, PROVIDER_PROFILES.ollama.contentLimit);
 
     try {
       const response = await withTimeout(
         this.client.chat({
           model: this.model,
           messages: [
-            { role: "system", content: SYSTEM_PROMPT },
+            { role: "system", content: getSystemPrompt(lang) },
             { role: "user", content: prompt }
           ],
           format: "json"

--- a/sidecar/providers/openai.ts
+++ b/sidecar/providers/openai.ts
@@ -1,8 +1,8 @@
 import OpenAI from "openai";
-import type { AIAnalysisResult, StockNews, QuantBundle } from "../../shared/types";
+import type { AIAnalysisResult, StockNews, QuantBundle, Language } from "../../shared/types";
 import type { AIProvider, ProviderKind } from "../ai";
 import { PROVIDER_PROFILES } from "../config";
-import { buildAnalysisPrompt, buildEnhancedPrompt, SYSTEM_PROMPT } from "../prompts";
+import { buildAnalysisPrompt, buildEnhancedPrompt, getSystemPrompt } from "../prompts";
 import { toErrorMessage, logger, parseJsonFromAi } from "../utils";
 
 /**
@@ -22,16 +22,17 @@ export class OpenAIProvider implements AIProvider {
     this.model = model;
   }
 
-  async analyze(symbol: string, news: StockNews[], quant?: QuantBundle): Promise<AIAnalysisResult> {
+  async analyze(symbol: string, news: StockNews[], quant?: QuantBundle, language?: Language): Promise<AIAnalysisResult> {
+    const lang = language ?? 'zh';
     const prompt = quant
-      ? buildEnhancedPrompt(symbol, news, quant, 'zh', PROVIDER_PROFILES.openai.contentLimit)
-      : buildAnalysisPrompt(symbol, news, 'zh', PROVIDER_PROFILES.openai.contentLimit);
+      ? buildEnhancedPrompt(symbol, news, quant, lang, PROVIDER_PROFILES.openai.contentLimit)
+      : buildAnalysisPrompt(symbol, news, lang, PROVIDER_PROFILES.openai.contentLimit);
 
     try {
       const response = await this.client.chat.completions.create({
         model: this.model,
         messages: [
-          { role: "system", content: SYSTEM_PROMPT },
+          { role: "system", content: getSystemPrompt(lang) },
           { role: "user", content: prompt }
         ],
         response_format: { type: "json_object" }


### PR DESCRIPTION
## Summary

- Add optional `language?: Language` param to the `AIProvider.analyze` interface
- Update all three providers (OpenAI, Anthropic, Ollama) to accept and apply the language, replacing hardcoded `'zh'` and `SYSTEM_PROMPT` constant with `getSystemPrompt(lang)` and parameterized prompt builders
- Propagate `config.language` from `analyzeNewsWithLLM` and `performFullAnalysis` through to `provider.analyze`, completing the end-to-end wire-up
- Fix `ai.test.ts` calls to `buildAnalysisPrompt` that broke when the `language` param was inserted before `contentLimit`

## Test plan

- [ ] `bunx tsc --noEmit` — no type errors
- [ ] `cd sidecar && bun test` — 297 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)